### PR TITLE
app: stop pinging blocklisted users

### DIFF
--- a/app/core.go
+++ b/app/core.go
@@ -1775,6 +1775,9 @@ func (a *App) formatChangeInfoLink(ch *gerrit.ChangeInfo) string {
 
 func (a *App) prepareUserLink(ctx context.Context, account *events.Account) string {
 	chatID := a.lookupGerritUser(ctx, account)
+	if a.isBlocklisted(ctx, chatID) {
+		return chatID
+	}
 	return a.formatUserLink(account, chatID)
 }
 


### PR DESCRIPTION
I am on the blocklisted users but I'm still getting pings. This
hopefully fixes that. Not tested.